### PR TITLE
Bugfix: test for isEmpty was inverted

### DIFF
--- a/src/AVL/Set.elm
+++ b/src/AVL/Set.elm
@@ -226,7 +226,7 @@ clear (Internal.AVLSet comparator _ _) =
 -}
 isEmpty : Set key -> Bool
 isEmpty set =
-    size set /= 0
+    size set == 0
 
 
 {-| Determine the number of elements in a set.


### PR DESCRIPTION
Test for isEmpty should be that size == 0, not that size /= 0.